### PR TITLE
Allow crypt_type to be configured

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -22,6 +22,7 @@ class Gateway extends AbstractGateway
         return [
             'merchantId'  => '',
             'merchantKey' => '',
+            'cryptType' => 1,
         ];
     }
 
@@ -43,6 +44,16 @@ class Gateway extends AbstractGateway
     public function setMerchantKey($value)
     {
         return $this->setParameter('merchantKey', $value);
+    }
+
+    public function getCryptType()
+    {
+        return $this->getParameter('cryptType');
+    }
+
+    public function setCryptType($value)
+    {
+        return $this->setParameter('cryptType', $value);
     }
 
     public function createCard(array $parameters = [])

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -32,6 +32,16 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('merchantKey', $value);
     }
 
+    public function getCryptType()
+    {
+        return $this->getParameter('cryptType');
+    }
+
+    public function setCryptType($value)
+    {
+        return $this->setParameter('cryptType', $value);
+    }
+
     public function getPaymentMethod()
     {
         return $this->getParameter('paymentMethod');

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -27,7 +27,7 @@ class AuthorizeRequest extends AbstractRequest
                 $res_purchase_cc->addChild('order_id', $this->getOrderNumber());
                 $res_purchase_cc->addChild('cust_id', 'Transaction_'.$this->getOrderNumber());
                 $res_purchase_cc->addChild('amount', $this->getAmount());
-                $res_purchase_cc->addChild('crypt_type', 1);
+                $res_purchase_cc->addChild('crypt_type', $this->getCryptType());
 
                 $data = $request->asXML();
                 break;

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -26,7 +26,7 @@ class CaptureRequest extends AbstractRequest
         $refund->addChild('order_id', $transactionReceipt->ReceiptId);
         $refund->addChild('comp_amount', $transactionReceipt->TransAmount);
         $refund->addChild('txn_number', $transactionReceipt->TransID);
-        $refund->addChild('crypt_type', 1);
+        $refund->addChild('crypt_type', $this->getCryptType());
         $refund->addChild('cust_id', $transactionReceipt->ReferenceNum);
         $refund->addChild('dynamic_descriptor', 'capture');
 

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -23,7 +23,7 @@ class CreateCardRequest extends AbstractRequest
             $res_add_cc->addChild('note', 'NA');
             $res_add_cc->addChild('pan', $card->getNumber());
             $res_add_cc->addChild('expdate', $card->getExpiryDate('my'));
-            $res_add_cc->addChild('crypt_type', 1);
+            $res_add_cc->addChild('crypt_type', $this->getCryptType());
 
             $avs_info = $res_add_cc->addChild('avs_info');
             $avs_info->addChild('avs_street_number', 'NA');

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -27,7 +27,7 @@ class PurchaseRequest extends AbstractRequest
                 $res_purchase_cc->addChild('order_id', $this->getOrderNumber());
                 $res_purchase_cc->addChild('cust_id', 'Transaction_'.$this->getOrderNumber());
                 $res_purchase_cc->addChild('amount', $this->getAmount());
-                $res_purchase_cc->addChild('crypt_type', 1);
+                $res_purchase_cc->addChild('crypt_type', $this->getCryptType());
 
                 $data = $request->asXML();
                 break;

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -26,7 +26,7 @@ class RefundRequest extends AbstractRequest
         $refund->addChild('order_id', $transactionReceipt->ReceiptId);
         $refund->addChild('amount', $this->getAmount());
         $refund->addChild('txn_number', $transactionReceipt->TransID);
-        $refund->addChild('crypt_type', 1);
+        $refund->addChild('crypt_type', $this->getCryptType());
         $refund->addChild('cust_id', $transactionReceipt->ReferenceNum);
         $refund->addChild('dynamic_descriptor', 'Refund');
 

--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -26,7 +26,7 @@ class VoidRequest extends AbstractRequest
         $refund->addChild('order_id', $transactionReceipt->ReceiptId);
         $refund->addChild('comp_amount', '0.00');
         $refund->addChild('txn_number', $transactionReceipt->TransID);
-        $refund->addChild('crypt_type', 1);
+        $refund->addChild('crypt_type', $this->getCryptType());
         $refund->addChild('cust_id', $transactionReceipt->ReferenceNum);
         $refund->addChild('dynamic_descriptor', 'void');
 

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -16,6 +16,11 @@ class GatewayTest extends GatewayTestCase
         $this->gateway = new Gateway($this->getHttpClient(), $this->getHttpRequest());
     }
 
+    public function test_crypt_type_default()
+    {
+        $this->assertEquals(1, $this->gateway->getCryptType());
+    }
+
     public function test_create_card_success()
     {
         $this->setMockHttpResponse('CreateCardSuccess.txt');

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -22,6 +22,7 @@ class AbstractRequestTest extends TestCase
         $this->request->initialize([
             'merchant_id'    => 'FAKE_MERCHANT_ID',
             'merchant_key'   => 'FAKE_MERCHANT_KEY',
+            'cryptType'      => 7,
             'orderNumber'    => 'DUMMY_ORDER_NUMBER',
             'paymentProfile' => 'FAKE_PAYMENT_PROFILE',
             'amount'         => 5.00,
@@ -30,6 +31,7 @@ class AbstractRequestTest extends TestCase
 
         $this->assertEquals('FAKE_MERCHANT_ID', $this->request->getMerchantId());
         $this->assertEquals('FAKE_MERCHANT_KEY', $this->request->getMerchantKey());
+        $this->assertEquals(7, $this->request->getCryptType());
         $this->assertEquals('DUMMY_ORDER_NUMBER', $this->request->getOrderNumber());
         $this->assertEquals('FAKE_PAYMENT_PROFILE', $this->request->getPaymentProfile());
         $this->assertEquals(5.00, $this->request->getAmount());


### PR DESCRIPTION
Most e-commerce website should set the `crypt_type` to `7`, but it's hard-coded in the various messages. This PR make this value configurable.

In order to be retro-compatible, the default value is kept to `1`.