### PR TITLE
Feature - Credit Card Purchase

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -133,7 +133,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                     break;
 
                 case 'description':
-                    if (strlen($value) > 20) {
+                    if (isset($value) && strlen($value) > 20) {
                         throw new InvalidRequestException("The $key parameter cannot be longer than 20 characters");
                     }
                     break;

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -106,9 +106,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     /**
      * Validate the request.
      *
-     * This method is called internally by gateways to avoid wasting time with an API call
-     * when the request is clearly invalid.
-     *
      * @param string ... a variable length list of required parameters
      * @throws InvalidRequestException
      * @see Omnipay\Common\ParametersTrait::validate()

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -119,6 +119,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 case 'orderNumber':
                     if (! isset($value)) {
                         throw new InvalidRequestException("The $key parameter is required");
+                    } elseif (empty($value)) {
+                        throw new InvalidRequestException("The $key parameter cannot be empty");
                     } elseif (strlen($value) > 50) {
                         throw new InvalidRequestException("The $key parameter cannot be longer than 50 characters");
                     }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -2,8 +2,34 @@
 
 namespace  Omnipay\Moneris\Message;
 
+use Omnipay\Common\Exception\InvalidRequestException;
+
 abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 {
+    const MAIL_ORDER_TELEPHONE_ORDER_SINGLE = 1;
+    const MAIL_ORDER_TELEPHONE_ORDER_RECURRING = 2;
+    const MAIL_ORDER_TELEPHONE_ORDER_INSTALMENT = 3;
+    const MAIL_ORDER_TELEPHONE_ORDER_UNKNOWN_CLASSIFICATION = 4;
+    const AUTHENTICATED_E_COMMERCE_TRANSACTION_VBV = 5;
+    const NON_AUTHENTICATED_E_COMMERCE_TRANSACTION_VBV = 6;
+    const SSL_ENABLED_MERCHANT = 7;
+
+    /**
+     * Allowable values for the e-commerce transaction category being processed
+     *
+     * @var array
+     * @see https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
+     */
+    const ECOMMERCE_INDICATORS = array(
+        self::MAIL_ORDER_TELEPHONE_ORDER_SINGLE,
+        self::MAIL_ORDER_TELEPHONE_ORDER_RECURRING,
+        self::MAIL_ORDER_TELEPHONE_ORDER_INSTALMENT,
+        self::MAIL_ORDER_TELEPHONE_ORDER_UNKNOWN_CLASSIFICATION,
+        self::AUTHENTICATED_E_COMMERCE_TRANSACTION_VBV,
+        self::NON_AUTHENTICATED_E_COMMERCE_TRANSACTION_VBV,
+        self::SSL_ENABLED_MERCHANT
+    );
+
     public $testEndpoint = 'https://esqa.moneris.com:443/gateway2/servlet/MpgRequest';
     public $liveEndpoint = 'https://www3.moneris.com:443/gateway2/servlet/MpgRequest';
 
@@ -75,6 +101,53 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     protected function getHttpMethod()
     {
         return 'POST';
+    }
+
+    /**
+     * Validate the request.
+     *
+     * This method is called internally by gateways to avoid wasting time with an API call
+     * when the request is clearly invalid.
+     *
+     * @param string ... a variable length list of required parameters
+     * @throws InvalidRequestException
+     * @see Omnipay\Common\ParametersTrait::validate()
+     */
+    public function validate(...$args)
+    {
+        foreach ($args as $key) {
+            $value = $this->parameters->get($key);
+
+            switch ($key) {
+                case 'orderNumber':
+                    if (! isset($value)) {
+                        throw new InvalidRequestException("The $key parameter is required");
+                    } elseif (strlen($value) > 50) {
+                        throw new InvalidRequestException("The $key parameter cannot be longer than 50 characters");
+                    }
+                    break;
+
+                case 'cryptType':
+                    if (! isset($value)) {
+                        throw new InvalidRequestException("The $key parameter is required");
+                    } elseif (! in_array($value, self::ECOMMERCE_INDICATORS)) {
+                        throw new InvalidRequestException("The $key is invalid");
+                    }
+                    break;
+
+                case 'description':
+                    if (strlen($value) > 20) {
+                        throw new InvalidRequestException("The $key parameter cannot be longer than 20 characters");
+                    }
+                    break;
+
+                default:
+                    if (! isset($value)) {
+                        throw new InvalidRequestException("The $key parameter is required");
+                    }
+                    break;
+            }
+        }
     }
 
     public function sendData($data)

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -18,7 +18,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      * Allowable values for the e-commerce transaction category being processed
      *
      * @var array
-     * @see https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
+     * @link https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
      */
     const ECOMMERCE_INDICATORS = array(
         self::MAIL_ORDER_TELEPHONE_ORDER_SINGLE,

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -15,20 +15,20 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     const SSL_ENABLED_MERCHANT = 7;
 
     /**
-     * Allowable values for the e-commerce transaction category being processed
+     * Allowable values for the e-commerce transaction category being processed.
      *
      * @var array
      * @link https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
      */
-    const ECOMMERCE_INDICATORS = array(
+    const ECOMMERCE_INDICATORS = [
         self::MAIL_ORDER_TELEPHONE_ORDER_SINGLE,
         self::MAIL_ORDER_TELEPHONE_ORDER_RECURRING,
         self::MAIL_ORDER_TELEPHONE_ORDER_INSTALMENT,
         self::MAIL_ORDER_TELEPHONE_ORDER_UNKNOWN_CLASSIFICATION,
         self::AUTHENTICATED_E_COMMERCE_TRANSACTION_VBV,
         self::NON_AUTHENTICATED_E_COMMERCE_TRANSACTION_VBV,
-        self::SSL_ENABLED_MERCHANT
-    );
+        self::SSL_ENABLED_MERCHANT,
+    ];
 
     public $testEndpoint = 'https://esqa.moneris.com:443/gateway2/servlet/MpgRequest';
     public $liveEndpoint = 'https://www3.moneris.com:443/gateway2/servlet/MpgRequest';

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -6,11 +6,43 @@ use Omnipay\Common\Exception\InvalidRequestException;
 
 class PurchaseRequest extends AbstractRequest
 {
+    /**
+     * CVD value is deliberately bypassed or is not provided by the merchant.
+     *
+     * @var int
+     * @see https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
+     */
+    const CVD_BYPASSED = 0;
+
+    /**
+     * CVD value is present.
+     *
+     * @var int
+     * @see https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
+     */
+    const CVD_PRESENT = 1;
+
+    /**
+     * CVD value is on the card, but is illegible.
+     *
+     * @var int
+     * @see https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
+     */
+    const CVD_ILLEGIBLE = 2;
+
+    /**
+     * Cardholder states that the card has no CVD imprint.
+     *
+     * @var int
+     * @see https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
+     */
+    const NO_CVD = 9;
+
     public function getData()
     {
         $data = null;
 
-        $this->validate('orderNumber', 'amount', 'paymentMethod');
+        $this->validate('orderNumber', 'cryptType', 'amount', 'paymentMethod');
 
         $paymentMethod = $this->getPaymentMethod();
 
@@ -32,7 +64,32 @@ class PurchaseRequest extends AbstractRequest
                 $data = $request->asXML();
                 break;
 
-            // Todo: card & token payment
+            case 'card':
+                $this->validate('card');
+
+                $request = new \SimpleXMLElement('<?xml version="1.0" encoding="utf-8"?><request></request>');
+                $request->addChild('store_id', $this->getMerchantId());
+                $request->addChild('api_token', $this->getMerchantKey());
+
+                $card = $this->getCard();
+
+                $purchase = $request->addChild('purchase');
+                $purchase->addChild('pan', $card->getNumber());
+                $purchase->addChild('expdate', $card->getExpiryDate('ym'));
+                $purchase->addChild('order_id', $this->getOrderNumber());
+                $purchase->addChild('cust_id', 'Transaction_'.$this->getOrderNumber());
+                $purchase->addChild('amount', $this->getAmount());
+                $purchase->addChild('crypt_type', $this->getCryptType());
+                $purchase->addChild('dynamic_descriptor', $this->getDescription());
+
+                $cvd_info = $purchase->addChild('cvd_info');
+                $cvd_info->addChild('cvd_indicator', self::CVD_PRESENT);
+                $cvd_info->addChild('cvd_value', $card->getCvv());
+
+                $data = $request->asXML();
+                break;
+
+            // Todo: token payment
 
             default:
                 throw new InvalidRequestException('Invalid payment method');

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -42,7 +42,7 @@ class PurchaseRequest extends AbstractRequest
     {
         $data = null;
 
-        $this->validate('orderNumber', 'cryptType', 'amount', 'paymentMethod');
+        $this->validate('orderNumber', 'cryptType', 'amount', 'paymentMethod', 'description');
 
         $paymentMethod = $this->getPaymentMethod();
 

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Moneris Purchase Request
+ * Moneris Purchase Request.
  */
 
 namespace Omnipay\Moneris\Message;
@@ -8,7 +8,7 @@ namespace Omnipay\Moneris\Message;
 use Omnipay\Common\Exception\InvalidRequestException;
 
 /**
- * Moneris Purchase Request class
+ * Moneris Purchase Request class.
  *
  * Moneris provides various payment related operations based on the data
  * submitted to their API. Use purchase for direct credit card payments

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -1,16 +1,92 @@
 <?php
+/**
+ * Moneris Purchase Request
+ */
 
 namespace Omnipay\Moneris\Message;
 
 use Omnipay\Common\Exception\InvalidRequestException;
 
+/**
+ * Moneris Purchase Request class
+ *
+ * Moneris provides various payment related operations based on the data
+ * submitted to their API. Use purchase for direct credit card payments
+ * and customer profile payments.
+ *
+ * ### Example
+ *
+ * #### Initialize Gateway
+ *
+ * <code>
+ *   // Create a gateway for the Moneris Gateway
+ *   // (routes to GatewayFactory::create)
+ *   $gateway = Omnipay::create('Moneris');
+ *
+ *   // Initialise the gateway
+ *   $gateway->initialize(array(
+ *       'merchantId'       => 'MyMonerisStoreId',
+ *       'merchantSecret'   => 'MyMonerisAPIToken',
+ *       'cryptType'        => 7,
+ *       'testMode'         => true, // Or false when you are ready for live transactions
+ *   ));
+ * </code>
+ *
+ * #### Direct Credit Card Payment
+ *
+ * This is for the use case where a customer has presented their
+ * credit card details and you intend to use the Moneris gateway
+ * for processing a transaction using that credit card data.
+ *
+ * <code>
+ *   // Create a credit card object
+ *   // DO NOT USE THESE CARD VALUES -- substitute your own
+ *   // see the documentation in the class header.
+ *   $card = new CreditCard(array(
+ *       'firstName'            => 'Example',
+ *       'lastName'             => 'User',
+ *       'number'               => '4111111111111111',
+ *       'expiryMonth'          => '01',
+ *       'expiryYear'           => '2020',
+ *       'cvv'                  => '123',
+ *       'billingAddress1'      => '1 Scrubby Creek Road',
+ *       'billingCountry'       => 'AU',
+ *       'billingCity'          => 'Scrubby Creek',
+ *       'billingPostcode'      => '4999',
+ *       'billingState'         => 'QLD',
+ *   ));
+ *
+ *   // Do a purchase transaction on the gateway
+ *   try {
+ *       $transaction = $gateway->purchase(array(
+ *           'orderNumber'   => 'XXXX-XXXX',
+ *           'amount'        => '10.00',
+ *           'description'   => 'This is a test purchase transaction.',
+ *           'card'          => $card,
+ *       ));
+ *       $response = $transaction->send();
+ *       $data = $response->getData();
+ *       echo "Gateway purchase response data == " . print_r($data, true) . "\n";
+ *
+ *       if ($response->isSuccessful()) {
+ *           echo "Purchase transaction was successful!\n";
+ *       }
+ *   } catch (\Exception $e) {
+ *       echo "Exception caught while attempting authorize.\n";
+ *       echo "Exception type == " . get_class($e) . "\n";
+ *       echo "Message == " . $e->getMessage() . "\n";
+ *   }
+ * </code>
+ *
+ * @link https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
+ */
 class PurchaseRequest extends AbstractRequest
 {
     /**
      * CVD value is deliberately bypassed or is not provided by the merchant.
      *
      * @var int
-     * @see https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
+     * @link https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
      */
     const CVD_BYPASSED = 0;
 
@@ -18,7 +94,7 @@ class PurchaseRequest extends AbstractRequest
      * CVD value is present.
      *
      * @var int
-     * @see https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
+     * @link https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
      */
     const CVD_PRESENT = 1;
 
@@ -26,7 +102,7 @@ class PurchaseRequest extends AbstractRequest
      * CVD value is on the card, but is illegible.
      *
      * @var int
-     * @see https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
+     * @link https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
      */
     const CVD_ILLEGIBLE = 2;
 
@@ -34,7 +110,7 @@ class PurchaseRequest extends AbstractRequest
      * Cardholder states that the card has no CVD imprint.
      *
      * @var int
-     * @see https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
+     * @link https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase
      */
     const NO_CVD = 9;
 

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -42,7 +42,7 @@ class PurchaseRequest extends AbstractRequest
     {
         $data = null;
 
-        $this->validate('orderNumber', 'cryptType', 'amount', 'paymentMethod', 'description');
+        $this->validate('paymentMethod', 'orderNumber', 'cryptType', 'amount', 'description');
 
         $paymentMethod = $this->getPaymentMethod();
 
@@ -71,11 +71,12 @@ class PurchaseRequest extends AbstractRequest
             case 'card':
                 $this->validate('card');
 
+                $card = $this->getCard();
+                $card->validate();
+
                 $request = new \SimpleXMLElement('<?xml version="1.0" encoding="utf-8"?><request></request>');
                 $request->addChild('store_id', $this->getMerchantId());
                 $request->addChild('api_token', $this->getMerchantKey());
-
-                $card = $this->getCard();
 
                 $purchase = $request->addChild('purchase');
                 $purchase->addChild('pan', $card->getNumber());

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -61,6 +61,10 @@ class PurchaseRequest extends AbstractRequest
                 $res_purchase_cc->addChild('amount', $this->getAmount());
                 $res_purchase_cc->addChild('crypt_type', $this->getCryptType());
 
+                if ($this->getDescription()) {
+                    $res_purchase_cc->addChild('dynamic_descriptor', $this->getDescription());
+                }
+
                 $data = $request->asXML();
                 break;
 
@@ -80,7 +84,10 @@ class PurchaseRequest extends AbstractRequest
                 $purchase->addChild('cust_id', 'Transaction_'.$this->getOrderNumber());
                 $purchase->addChild('amount', $this->getAmount());
                 $purchase->addChild('crypt_type', $this->getCryptType());
-                $purchase->addChild('dynamic_descriptor', $this->getDescription());
+
+                if ($this->getDescription()) {
+                    $purchase->addChild('dynamic_descriptor', $this->getDescription());
+                }
 
                 $cvd_info = $purchase->addChild('cvd_info');
                 $cvd_info->addChild('cvd_indicator', self::CVD_PRESENT);

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -154,7 +154,7 @@ class PurchaseRequestTest extends TestCase
             'cryptType'     => 1,
             'cardReference' => 'FAKE_CARD_REFERENCE',
             'amount'        => 5.00,
-            'description'   => "ZGL5Dp0htqaKRzfeIOiVJm",    // randomly generated 22 character string
+            'description'   => "ZGL5Dp0htqaKRzfeIOiVJm",
         ]);
 
         $this->expectException(InvalidRequestException::class);
@@ -182,7 +182,6 @@ class PurchaseRequestTest extends TestCase
             'cryptType'     => 1,
             'amount'        => 5.00,
         ]);
-
 
         $this->expectException(InvalidRequestException::class);
         $this->request->send();

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Moneris\Tests\Message;
 
+use Omnipay\Common\Exception\InvalidCreditCardException;
 use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\Moneris\Message\PurchaseRequest;
 use Omnipay\Tests\TestCase;
@@ -17,11 +18,25 @@ class PurchaseRequestTest extends TestCase
         $this->request = new PurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
     }
 
-    public function test_an_invalid_payment_method_should_throw_an_exception_for_the_purchase_request()
+    public function test_missing_payment_method_should_throw_an_exception_for_the_purchase_request()
     {
         $this->request->initialize([
             'orderNumber'   => 'XXXX-XXXX',
+            'cryptType'     => 1,
+            'cardReference' => 'FAKE_CARD_REFERENCE',
+            'amount'        => 5.00,
+        ]);
+
+        $this->expectException(InvalidRequestException::class);
+        $this->request->send();
+    }
+
+    public function test_an_invalid_payment_method_should_throw_an_exception_for_the_purchase_request()
+    {
+        $this->request->initialize([
             'paymentMethod' => 'test',
+            'orderNumber'   => 'XXXX-XXXX',
+            'cryptType'     => 1,
             'cardReference' => 'FAKE_CARD_REFERENCE',
             'amount'        => 5.00,
         ]);
@@ -35,5 +50,160 @@ class PurchaseRequestTest extends TestCase
         }
 
         $this->fail('Purchase with an invalid payment method did not throw an InvalidRequestException.');
+    }
+
+    public function test_missing_order_number_should_throw_an_exception_for_the_purchase_request()
+    {
+        $this->request->initialize([
+            'paymentMethod' => 'payment_profile',
+            'cryptType'     => 1,
+            'cardReference' => 'FAKE_CARD_REFERENCE',
+            'amount'        => 5.00,
+        ]);
+
+        $this->expectException(InvalidRequestException::class);
+        $this->request->send();
+    }
+
+    public function test_an_invalid_order_number_should_throw_an_exception_for_the_purchase_request()
+    {
+        $this->request->initialize([
+            'paymentMethod' => 'payment_profile',
+            'orderNumber'   => '',
+            'cryptType'     => 1,
+            'cardReference' => 'FAKE_CARD_REFERENCE',
+            'amount'        => 5.00,
+        ]);
+
+        try {
+            $this->request->send();
+        } catch (InvalidRequestException $e) {
+            $this->assertEquals('', $this->request->getOrderNumber());
+
+            return;
+        }
+        $this->fail('Purchase with an invalid order number did not throw an InvalidRequestException.');
+    }
+
+    public function test_missing_crypt_type_should_throw_an_exception_for_the_purchase_request()
+    {
+        $this->request->initialize([
+            'paymentMethod' => 'payment_profile',
+            'orderNumber'   => 'XXXX-XXXX',
+            'cardReference' => 'FAKE_CARD_REFERENCE',
+            'amount'        => 5.00,
+        ]);
+
+        $this->expectException(InvalidRequestException::class);
+        $this->request->send();
+    }
+
+    public function test_an_invalid_crypt_type_should_throw_an_exception_for_the_purchase_request()
+    {
+        $this->request->initialize([
+            'paymentMethod' => 'payment_profile',
+            'orderNumber'   => 'XXXX-XXXX',
+            'cryptType'     => 0,
+            'cardReference' => 'FAKE_CARD_REFERENCE',
+            'amount'        => 5.00,
+        ]);
+
+        try {
+            $this->request->send();
+        } catch (InvalidRequestException $e) {
+            $this->assertEquals(0, $this->request->getCryptType());
+
+            return;
+        }
+
+        $this->fail('Purchase with an invalid crypt type did not throw an InvalidRequestException.');
+    }
+
+    public function test_missing_amount_should_throw_an_exception_for_the_purchase_request()
+    {
+        $this->request->initialize([
+            'paymentMethod' => 'payment_profile',
+            'orderNumber'   => 'XXXX-XXXX',
+            'cryptType'     => 1,
+            'cardReference' => 'FAKE_CARD_REFERENCE',
+        ]);
+
+        $this->expectException(InvalidRequestException::class);
+        $this->request->send();
+    }
+
+    public function test_an_invalid_amount_should_throw_an_exception_for_the_purchase_request()
+    {
+        $this->request->initialize([
+            'paymentMethod' => 'payment_profile',
+            'orderNumber'   => 'XXXX-XXXX',
+            'cryptType'     => 1,
+            'cardReference' => 'FAKE_CARD_REFERENCE',
+            'amount'        => -5,
+        ]);
+
+        $this->expectException(InvalidRequestException::class);
+        $this->request->send();
+    }
+
+    public function test_an_invalid_description_should_throw_an_exception_for_the_purchase_request()
+    {
+        $this->request->initialize([
+            'paymentMethod' => 'payment_profile',
+            'orderNumber'   => 'XXXX-XXXX',
+            'cryptType'     => 1,
+            'cardReference' => 'FAKE_CARD_REFERENCE',
+            'amount'        => 5.00,
+            'description'   => "ZGL5Dp0htqaKRzfeIOiVJm",    // randomly generated 22 character string
+        ]);
+
+        $this->expectException(InvalidRequestException::class);
+        $this->request->send();
+    }
+
+    public function test_missing_a_card_reference_should_throw_an_exception_for_the_purchase_request()
+    {
+        $this->request->initialize([
+            'paymentMethod' => 'payment_profile',
+            'orderNumber'   => 'XXXX-XXXX',
+            'cryptType'     => 1,
+            'amount'        => 5.00,
+        ]);
+
+        $this->expectException(InvalidRequestException::class);
+        $this->request->send();
+    }
+
+    public function test_missing_a_card_should_throw_an_exception_for_the_purchase_request()
+    {
+        $this->request->initialize([
+            'paymentMethod' => 'card',
+            'orderNumber'   => 'XXXX-XXXX',
+            'cryptType'     => 1,
+            'amount'        => 5.00,
+        ]);
+
+
+        $this->expectException(InvalidRequestException::class);
+        $this->request->send();
+    }
+
+    public function test_an_expired_card_should_throw_an_exception_for_the_purchase_request()
+    {
+        $this->request->initialize([
+            'paymentMethod' => 'card',
+            'orderNumber'   => 'XXXX-XXXX',
+            'cryptType'     => 1,
+            'amount'        => 5.00,
+            'card'          => [
+                'number'        => '4242424242424242',
+                'expiryMonth'   => date('m'),
+                'expiryYear'    => date('Y') - 1,
+                'cvv'           => 123,
+            ],
+        ]);
+
+        $this->expectException(InvalidCreditCardException::class);
+        $this->request->send();
     }
 }

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -154,7 +154,7 @@ class PurchaseRequestTest extends TestCase
             'cryptType'     => 1,
             'cardReference' => 'FAKE_CARD_REFERENCE',
             'amount'        => 5.00,
-            'description'   => "ZGL5Dp0htqaKRzfeIOiVJm",
+            'description'   => 'ZGL5Dp0htqaKRzfeIOiVJm',
         ]);
 
         $this->expectException(InvalidRequestException::class);


### PR DESCRIPTION
- Adds support for `card` purchases
- Adds custom validation for `orderNumber`, `cryptType`, and `description` parameters
- Adds tests for purchase requests with missing or invalid `paymentMethod`, `orderNumber`, `cryptType`, `cardReference`, `card`, `description`, and `amount`.



